### PR TITLE
Add support for simplecov 0.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0.5, 3.1, 3.2, 3.3]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- allow simplecov 0.22 as dependency
+- include ruby 3.x in test suite
+
 ## [0.2.0] - 2022-07-11
 
 - improve lines grouping

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     simplecov-review (0.2.0)
-      simplecov (~> 0.21.2)
+      simplecov (>= 0.21.2, < 0.23)
 
 GEM
   remote: https://rubygems.org/
@@ -11,8 +11,10 @@ GEM
     diff-lcs (1.4.4)
     docile (1.4.0)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.1.1)
@@ -44,7 +46,7 @@ GEM
     rubocop-rspec (2.5.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -54,6 +56,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-18
   x86_64-linux
 

--- a/simplecov-review.gemspec
+++ b/simplecov-review.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'simplecov', '~> 0.21.2'
+  spec.add_dependency 'simplecov', '>= 0.21.2', '< 0.23'
 end


### PR DESCRIPTION
Update CI to include latest Ruby 3.x versions